### PR TITLE
fix(category): Ajusta formatação html/css dos textos SEO nas páginas de categoria

### DIFF
--- a/sections/Content/TextSeo.tsx
+++ b/sections/Content/TextSeo.tsx
@@ -1,61 +1,67 @@
-import { useId } from '../../sdk/useId.ts'
+import { useId } from "../../sdk/useId.ts";
 
 /**
  * @titleBy matcher
  */
 interface SEO {
-    /**
-     * @description Coloque a URL do departamento ex: /feminino, /feminino/inverno
-     */
-    matcher: string
-    /**
-     * @title Texto
-     */
-    /**
-     * @format textarea
-     */
-    text: string
+  /**
+   * @description Coloque a URL do departamento ex: /feminino, /feminino/inverno
+   */
+  matcher: string;
+  /**
+   * @title Texto
+   */
+  /**
+   * @format textarea
+   */
+  text: string;
 }
 
 interface Props {
-    section: SEO[]
+  section: SEO[];
 }
 
 export default function (props: ReturnType<typeof loader>) {
-    if (!props || !Object.keys(props).length) return null
+  if (!props || !Object.keys(props).length) return null;
 
-    const id = useId()
+  const id = useId();
 
-    const { text } = props
+  const { text } = props;
 
-    return (
-        <div class="container flex flex-row gap-x-8">
-            <div class="hidden sm:block w-min min-w-[300px]"></div>
-            <div
-                id='seo'
-                class='flex flex-col lg:flex-row gap-x-10 gap-y-6 max-w-[96px] w-[95%] mx-auto mb-6 lg:mb-10'
-            >
-                <input type='checkbox' id={id} class='hidden peer' />
+  return (
+    <div class="container flex flex-row gap-x-8">
+      <div class="hidden sm:block w-min min-w-[300px]"></div>
+      <div
+        id="seo"
+        class="flex flex-col lg:flex-row gap-x-10 gap-y-6 w-[100%] mx-auto mb-6 lg:mb-10 seo-text"
+      >
+        <input type="checkbox" id={id} class="hidden peer" />
 
-                <div class='flex flex-col gap-3 flex-1 group'>
-                    <div
-                        dangerouslySetInnerHTML={{ __html: text }}
-                        class='prose-like max-h-[96px] overflow-hidden peer-checked:group-[]:max-h-none'
-                    />
+        <div class="flex flex-col gap-3 flex-1 group">
+          <div
+            dangerouslySetInnerHTML={{ __html: text }}
+            class="prose-like max-h-[96px] overflow-hidden peer-checked:group-[]:max-h-none"
+          />
 
-                    <label
-                        for={id}
-                        class='text-brand text-sm font-normal text-center underline underline-offset-2 cursor-pointer'
-                    >
-                        <span class='block peer-checked:group-[]:hidden text-center'>Ver mais</span>
-                        <span class='hidden peer-checked:group-[]:block text-center'>Ver menos</span>
-                    </label>
-                </div>
-            </div>
+          <label
+            for={id}
+            class="text-brand text-sm font-normal text-center underline underline-offset-2 cursor-pointer"
+          >
+            <span class="block peer-checked:group-[]:hidden text-center">
+              Ver mais
+            </span>
+            <span class="hidden peer-checked:group-[]:block text-center">
+              Ver menos
+            </span>
+          </label>
         </div>
-    )
+      </div>
+    </div>
+  );
 }
 
 export const loader = ({ section: s }: Props, req: Request) => {
-    return (s ?? []).find(({ matcher }) => new URLPattern({ pathname: matcher }).test(req.url))
-}
+  return (s ?? []).find(({ matcher }) =>
+    new URLPattern({ pathname: matcher }).test(req.url)
+  );
+};

--- a/tailwind.css
+++ b/tailwind.css
@@ -2,11 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Roboto+Condensed:wght@300;400;600&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Roboto+Condensed:wght@300;400;600&display=swap");
 
 @layer base {
-
-
   /* Allow changing font family via CMS */
   html {
     font-family: var(--font-family);
@@ -17,8 +15,8 @@
   }
 
   /** Remove default styles from input[type=number] */
-  input[type=number]::-webkit-inner-spin-button,
-  input[type=number]::-webkit-outer-spin-button {
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
@@ -45,16 +43,16 @@
 }
 
 .group:disabled .group-disabled\:animate-progress {
-  animation: progress-frame ease normal
+  animation: progress-frame ease normal;
 }
 
 @keyframes progress-frame {
   0% {
-    --dot-progress: 0%
+    --dot-progress: 0%;
   }
 
   to {
-    --dot-progress: 100%
+    --dot-progress: 100%;
   }
 }
 
@@ -132,9 +130,9 @@
   margin: 1em 0 15px 0;
 }
 
-.markdown-body h1+p,
-.markdown-body h2+p,
-.markdown-body h3+p {
+.markdown-body h1 + p,
+.markdown-body h2 + p,
+.markdown-body h3 + p {
   margin-top: 10px;
 }
 
@@ -144,9 +142,9 @@
 
 .markdown-body code,
 .markdown-body pre {
-  background-color: #F8F8F8;
+  background-color: #f8f8f8;
   border-radius: 3px;
-  border: 1px solid #DDD;
+  border: 1px solid #ddd;
   font-family: Consolas, "Liberation Mono", Courier, monospace;
   font-size: 12px;
   margin: 0 2px;
@@ -162,5 +160,34 @@
 }
 
 .Nunito {
-  font-family: 'Nunito';
+  font-family: "Nunito";
+}
+
+.seo-text h1 {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 21px;
+  color: #353535 !important;
+  margin-bottom: 16px;
+}
+
+.seo-text h2 {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 21px;
+  color: #353535 !important;
+}
+
+.seo-text p {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  line-height: 24px;
+  color: #353535 !important;
+}
+
+.seo-text strong {
+  font-weight: 700;
 }


### PR DESCRIPTION
Nessa branch está o desenvolvimento da tarefa: https://runrun.it/pt-BR/tasks/921

Nela foram desenvolvidos alguns ajustes de CSS no texto de SEO das páginas de categoria para ficar semelhante ao figma. Além disso não foi necessário implementar modificações nas tags pelo código, pois atualmente pelo código já podem ser cadastradas dinâmicamente as tags HTMLS e os textos