### PR TITLE
fix: ajusta formatação das tags de seo nas páginas de categoria

### DIFF
--- a/sections/Content/TextSeo.tsx
+++ b/sections/Content/TextSeo.tsx
@@ -33,8 +33,8 @@ export default function (props: ReturnType<typeof loader>) {
             <div class="hidden sm:block w-min min-w-[300px]"></div>
             <div
                 id='seo'
-                class='flex flex-col lg:flex-row gap-x-10 gap-y-6 max-w-[96px] w-[95%] mx-auto mb-6 lg:mb-10'
-            >
+                class="flex flex-col lg:flex-row gap-x-10 gap-y-6 w-full mb-6 lg:mb-10 seo-text"
+                >
                 <input type='checkbox' id={id} class='hidden peer' />
 
                 <div class='flex flex-col gap-3 flex-1 group'>

--- a/tailwind.css
+++ b/tailwind.css
@@ -164,3 +164,33 @@
 .Nunito {
   font-family: 'Nunito';
 }
+
+
+.seo-text h1 {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 21px;
+  color: #353535 !important;
+  margin-bottom: 16px;
+}
+
+.seo-text h2 {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 18px;
+  line-height: 21px;
+  color: #353535 !important;
+}
+
+.seo-text p {
+  font-family: "Commissioner", sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  line-height: 24px;
+  color: #353535 !important;
+}
+
+.seo-text strong {
+  font-weight: 700;
+}


### PR DESCRIPTION
Nessa branch está o desenvolvimento da tarefa: https://runrun.it/pt-BR/tasks/921

Nela foram desenvolvidos alguns ajustes de CSS no texto de SEO das páginas de categoria para ficar semelhante ao figma. Além disso não foi necessário implementar modificações nas tags pelo código, pois atualmente pelo código já podem ser cadastradas dinâmicamente as tags HTMLS e os textos